### PR TITLE
chore: move provider creation code to the common method

### DIFF
--- a/cmd/capi/cmd/bootstrap_cluster.go
+++ b/cmd/capi/cmd/bootstrap_cluster.go
@@ -20,7 +20,7 @@ var clusterCmdFlags struct {
 
 var deployOptions = capi.DefaultDeployOptions()
 
-var awsDeployOptions = infrastructure.AWSDeployOptions()
+var awsDeployOptions = infrastructure.NewAWSDeployOptions()
 
 var clusterCmd = &cobra.Command{
 	Use:   "cluster",

--- a/pkg/capi/deploy.go
+++ b/pkg/capi/deploy.go
@@ -287,7 +287,7 @@ func (clusterAPI *Manager) DestroyCluster(ctx context.Context, name, namespace, 
 				return nil
 			}
 
-			return retry.ExpectedError(err)
+			return err
 		}
 
 		return retry.ExpectedError(fmt.Errorf("cluster is being deleted"))


### PR DESCRIPTION
Additionally, separate provider creation from it's configuration phases
to properly parse provider name then get the default config for it.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>