### PR TITLE
fix: do CAPI init once if several infra providers are defined

### DIFF
--- a/pkg/capi/infrastructure/aws.go
+++ b/pkg/capi/infrastructure/aws.go
@@ -201,7 +201,7 @@ func (s *AWSProvider) WaitReady(ctx context.Context, clientset *kubernetes.Clien
 			return retry.ExpectedError(err)
 		}
 
-		if deployment.Status.ReadyReplicas != deployment.Status.Replicas {
+		if deployment.Status.ReadyReplicas != deployment.Status.Replicas || deployment.Status.ReadyReplicas == 0 {
 			return retry.ExpectedError(fmt.Errorf("%d of %d replicas ready", deployment.Status.ReadyReplicas, deployment.Status.Replicas))
 		}
 


### PR DESCRIPTION
And fail if no providers were set.
And change provider healthcheck to always verify that controller has ready replicas.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>