### PR TITLE
feat: add ability to detect CAPI version and installed infra providers

### DIFF
--- a/pkg/capi/check.go
+++ b/pkg/capi/check.go
@@ -20,12 +20,12 @@ import (
 
 // CheckClusterReady verifies that cluster ready from the CAPI point of view.
 //nolint:cyclop,gocyclo,gocognit
-func CheckClusterReady(ctx context.Context, metalClient client.Client, clusterName, version string) error {
+func (clusterAPI *Manager) CheckClusterReady(ctx context.Context, metalClient client.Client, clusterName string) error {
 	var cluster unstructured.Unstructured
 
 	cluster.SetGroupVersionKind(
 		schema.GroupVersionKind{
-			Version: version,
+			Version: clusterAPI.version,
 			Group:   "cluster.x-k8s.io",
 			Kind:    "Cluster",
 		},
@@ -122,7 +122,7 @@ func CheckClusterReady(ctx context.Context, metalClient client.Client, clusterNa
 
 	machineDeployments.SetGroupVersionKind(
 		schema.GroupVersionKind{
-			Version: version,
+			Version: clusterAPI.version,
 			Group:   "cluster.x-k8s.io",
 			Kind:    "MachineDeployment",
 		},

--- a/pkg/capi/cluster.go
+++ b/pkg/capi/cluster.go
@@ -41,7 +41,7 @@ type Cluster struct {
 
 // NewCluster fetches cluster info from the CAPI state.
 //nolint:gocyclo,cyclop
-func (clusterAPI *Manager) NewCluster(ctx context.Context, clusterName, version string) (*Cluster, error) {
+func (clusterAPI *Manager) NewCluster(ctx context.Context, clusterName string) (*Cluster, error) {
 	var (
 		cluster      unstructured.Unstructured
 		controlPlane unstructured.Unstructured
@@ -55,7 +55,7 @@ func (clusterAPI *Manager) NewCluster(ctx context.Context, clusterName, version 
 
 	cluster.SetGroupVersionKind(
 		schema.GroupVersionKind{
-			Version: version,
+			Version: clusterAPI.version,
 			Group:   "cluster.x-k8s.io",
 			Kind:    "Cluster",
 		},
@@ -63,7 +63,7 @@ func (clusterAPI *Manager) NewCluster(ctx context.Context, clusterName, version 
 
 	machines.SetGroupVersionKind(
 		schema.GroupVersionKind{
-			Version: version,
+			Version: clusterAPI.version,
 			Group:   "cluster.x-k8s.io",
 			Kind:    "Machine",
 		},
@@ -204,7 +204,7 @@ func (clusterAPI *Manager) NewCluster(ctx context.Context, clusterName, version 
 		controlPlaneNodes: controlPlaneNodes,
 		workerNodes:       workerNodes,
 		client:            talosClient,
-		capiVersion:       version,
+		capiVersion:       clusterAPI.version,
 	}, nil
 }
 


### PR DESCRIPTION
Make manager fetch existing CAPI state, so it should be possible to
manage clusters even if CAPI wasn't initialized in the same code path.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>