### PR TITLE
feat: add API method to get CAPI version

### DIFF
--- a/pkg/capi/capi.go
+++ b/pkg/capi/capi.go
@@ -334,6 +334,11 @@ func (clusterAPI *Manager) FetchState(ctx context.Context) error {
 	return nil
 }
 
+// Version returns installed CAPI version.
+func (clusterAPI *Manager) Version() string {
+	return clusterAPI.version
+}
+
 type ref struct {
 	types.NamespacedName
 	gvk schema.GroupVersionKind


### PR DESCRIPTION
For convenience of working with CAPI resources directly from kubernetes
client outside of CAPI utils.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>