### PR TITLE
feat: support getting cluster template files by http urls

### DIFF
--- a/pkg/capi/deploy.go
+++ b/pkg/capi/deploy.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"strconv"
 	"time"
 
@@ -37,6 +36,7 @@ type DeployOptions struct {
 	ClusterNamespace  string
 	TalosVersion      string
 	KubernetesVersion string
+	TemplateFile      string
 	Template          []byte
 	ControlPlaneNodes int64
 	WorkerNodes       int64
@@ -110,17 +110,7 @@ func WithKubernetesVersion(version string) DeployOption {
 // WithTemplateFile load cluster template from the file.
 func WithTemplateFile(path string) DeployOption {
 	return func(o *DeployOptions) error {
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-
-		defer f.Close() //nolint:errcheck
-
-		o.Template, err = ioutil.ReadAll(f)
-		if err != nil {
-			return err
-		}
+		o.TemplateFile = path
 
 		return nil
 	}
@@ -232,6 +222,10 @@ func (clusterAPI *Manager) DeployCluster(ctx context.Context, clusterName string
 		}
 
 		defer file.Close() //nolint:errcheck
+	} else if options.TemplateFile != "" {
+		templateOptions.URLSource = &client.URLSourceOptions{
+			URL: options.TemplateFile,
+		}
 	}
 
 	vars, err := provider.ClusterVars(options.providerOptions)

--- a/pkg/capi/infrastructure/aws.go
+++ b/pkg/capi/infrastructure/aws.go
@@ -73,6 +73,7 @@ type AWSDeployOptions struct {
 	VPCID                     string
 	Subnet                    string
 	CloudProviderVersion      string
+	CalicoVersion             string
 	ControlPlaneVolSize       int64
 	NodeVolSize               int64
 }
@@ -87,6 +88,7 @@ func NewAWSDeployOptions() *AWSDeployOptions {
 		NodeMachineType:         "t3.large",
 		NodeIAMProfile:          "CAPI_AWS_Worker",
 		CloudProviderVersion:    "v1.20.0-alpha.0",
+		CalicoVersion:           "3.18",
 	}
 }
 
@@ -182,6 +184,7 @@ func (s *AWSProvider) ClusterVars(opts interface{}) (Variables, error) {
 		"AWS_NODE_IAM_PROFILE":              deployOptions.NodeIAMProfile,
 		"AWS_NODE_AMI_ID":                   deployOptions.NodeAMIID,
 		"AWS_CLOUD_PROVIDER_VERSION":        deployOptions.CloudProviderVersion,
+		"CALICO_VERSION":                    deployOptions.CalicoVersion,
 	}
 
 	return vars, nil


### PR DESCRIPTION
This is required if we want capi-utils to use our templates repo.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>