### PR TITLE
fix: properly define calico version

### DIFF
--- a/pkg/capi/infrastructure/aws.go
+++ b/pkg/capi/infrastructure/aws.go
@@ -88,7 +88,7 @@ func NewAWSDeployOptions() *AWSDeployOptions {
 		NodeMachineType:         "t3.large",
 		NodeIAMProfile:          "CAPI_AWS_Worker",
 		CloudProviderVersion:    "v1.20.0-alpha.0",
-		CalicoVersion:           "3.18",
+		CalicoVersion:           "v3.18",
 	}
 }
 


### PR DESCRIPTION
Missed `v`.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>