### PR TITLE
fix: use correct name for getting talosconfig secret

### DIFF
--- a/pkg/capi/cluster.go
+++ b/pkg/capi/cluster.go
@@ -116,7 +116,7 @@ func (cluster *Cluster) Sync(ctx context.Context) error {
 
 	if err = cluster.manager.runtimeClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace(),
-		Name:      cluster.Name(),
+		Name:      cluster.Name() + "-talosconfig",
 	}, &talosConfig); err != nil {
 		return err
 	}


### PR DESCRIPTION
Forgot `-talosconfig` suffix.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>