### PR TITLE
chore: update `DefaultDeployOptions` to Talos `v1.12`

### DIFF
--- a/pkg/capi/deploy.go
+++ b/pkg/capi/deploy.go
@@ -48,7 +48,7 @@ func DefaultDeployOptions() *DeployOptions {
 		ControlPlaneNodes: 1,
 		WorkerNodes:       1,
 		ClusterNamespace:  "default",
-		TalosVersion:      "v1.11",
+		TalosVersion:      "v1.12",
 		KubernetesVersion: constants.DefaultKubernetesVersion,
 	}
 }


### PR DESCRIPTION
Bump Talos version in `DefaultDeployOptions` (I think this is fine to do now?)